### PR TITLE
チャット機能のバグ修正

### DIFF
--- a/CHANGELOG_TECHNICLIP.md
+++ b/CHANGELOG_TECHNICLIP.md
@@ -1,22 +1,26 @@
 # リリースノート
 このドキュメントは、てくにくりっぷフォークの変更点のみを含みます。
 
+## 1.7.0(Based 4.15.0)
+- Fix: チャットのもっと見るが機能しない [#7](https://github.com/buachigithub/cherrypick/pull/7)
+- Fix: チャットが空白や改行のみでも送れる [#7](https://github.com/buachigithub/cherrypick/pull/7)
+
 ## 1.6.0(Based 4.15.0)
 > [!NOTE]
 > このバージョンより命名規則が変更されました(1.0.6→1.6.0)
-- Feat: CherryPick 4.15.0をマージ #6
+- Feat: CherryPick 4.15.0をマージ [#6](https://github.com/buachigithub/cherrypick/pull/6)
 
 ## 1.0.5(Based 4.15.0-beta.2)
-- Feat: CherryPick 4.15.0-beta.2をマージ #5
-- Fix: misskey-jsをcherrypick-jsに変更 #5
-- Corepackの署名エラーを修正 d8fc3ce
+- Feat: CherryPick 4.15.0-beta.2をマージ [#5](https://github.com/buachigithub/cherrypick/pull/5)
+- Fix: misskey-jsをcherrypick-jsに変更 [#5](https://github.com/buachigithub/cherrypick/pull/5)
+- Corepackの署名エラーを修正 [d8fc3ce](https://github.com/buachigithub/cherrypick/commit/d8fc3ce6a632913920ca9f9ab1c60c23d78a5a42)
 
 ## 1.0.4(Based 4.15.0-beta.1)
-- Feat: 自動フォローバック #4
+- Feat: 自動フォローバック [#4](https://github.com/buachigithub/cherrypick/pull/4)
 
 ## 1.0.3(Based 4.15.0-beta.1)
-- Fix: ListenBrainzのNowPlaying投稿用ウィジェットの実装 #3
+- Fix: ListenBrainzのNowPlaying投稿用ウィジェットの実装 [#3](https://github.com/buachigithub/cherrypick/pull/3)
 
 ## 1.0.2(Based 4.15.0-beta.1)
-- Feat: フォローしているユーザーの鍵/DMをアンテナに乗せるように #2
-- Feat: プロフィールのListenBrainzの連合・ListenBrainzのNowPlaying投稿用ウィジェット #1
+- Feat: フォローしているユーザーの鍵/DMをアンテナに乗せるように [#2](https://github.com/buachigithub/cherrypick/pull/2)
+- Feat: プロフィールのListenBrainzの連合・ListenBrainzのNowPlaying投稿用ウィジェット [#1](https://github.com/buachigithub/cherrypick/pull/1)

--- a/CHANGELOG_TECHNICLIP.md
+++ b/CHANGELOG_TECHNICLIP.md
@@ -1,0 +1,22 @@
+# リリースノート
+このドキュメントは、てくにくりっぷフォークの変更点のみを含みます。
+
+## 1.6.0(Based 4.15.0)
+> [!NOTE]
+> このバージョンより命名規則が変更されました(1.0.6→1.6.0)
+- Feat: CherryPick 4.15.0をマージ #6
+
+## 1.0.5(Based 4.15.0-beta.2)
+- Feat: CherryPick 4.15.0-beta.2をマージ #5
+- Fix: misskey-jsをcherrypick-jsに変更 #5
+- Corepackの署名エラーを修正 d8fc3ce
+
+## 1.0.4(Based 4.15.0-beta.1)
+- Feat: 自動フォローバック #4
+
+## 1.0.3(Based 4.15.0-beta.1)
+- Fix: ListenBrainzのNowPlaying投稿用ウィジェットの実装 #3
+
+## 1.0.2(Based 4.15.0-beta.1)
+- Feat: フォローしているユーザーの鍵/DMをアンテナに乗せるように #2
+- Feat: プロフィールのListenBrainzの連合・ListenBrainzのNowPlaying投稿用ウィジェット #1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cherrypick",
-	"version": "4.15.0-techniclip-1.6.0",
+	"version": "4.15.0-techniclip-1.7.0",
 	"basedMisskeyVersion": "2025.2.0",
 	"codename": "nasubi",
 	"repository": {

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -53,7 +53,7 @@ import { defaultStore } from '@/store.js';
 import { MisskeyEntity } from '@/types/date-separated-list.js';
 import { i18n } from '@/i18n.js';
 
-const SECOND_FETCH_LIMIT = 30;
+const SECOND_FETCH_LIMIT = 99;
 const TOLERANCE = 16;
 const APPEAR_MINIMUM_INTERVAL = 600;
 
@@ -308,7 +308,7 @@ const fetchMoreAhead = async (): Promise<void> => {
 		...(props.pagination.offsetMode ? {
 			offset: items.value.size,
 		} : {
-			sinceId: Array.from(items.value.keys()).at(-1),
+			untilId: Array.from(items.value.keys()).at(-1),
 		}),
 	}).then(res => {
 		if (res.length === 0) {

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -53,7 +53,7 @@ import { defaultStore } from '@/store.js';
 import { MisskeyEntity } from '@/types/date-separated-list.js';
 import { i18n } from '@/i18n.js';
 
-const SECOND_FETCH_LIMIT = 99;
+const SECOND_FETCH_LIMIT = 30;
 const TOLERANCE = 16;
 const APPEAR_MINIMUM_INTERVAL = 600;
 

--- a/packages/frontend/src/pages/messaging/messaging-room.form.vue
+++ b/packages/frontend/src/pages/messaging/messaging-room.form.vue
@@ -67,7 +67,10 @@ const typing = () => {
 };
 
 const draftKey = computed(() => props.user ? 'user:' + props.user.id : 'group:' + props.group?.id);
-const canSend = computed(() => (text.value != null && text.value !== '') || file.value != null);
+const canSend = computed(() => {
+	const replacedText = text.value.replace(/[\s\u200B-\u200D\uFEFF]/g, '');
+	return (replacedText != null && replacedText !== '') || file.value != null;
+});
 
 watch([text.value, file.value], saveDraft);
 


### PR DESCRIPTION
<!-- ℹ 읽어주세요 / お読みください / README
PR을 보내주셔서 감사합니다! PR을 작성하기 전에 기여 가이드를 먼저 확인해 주세요:
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md
-->

## What
- 空白や改行のみの送信をできないように
- もっと見るが機能するように
## Why
- 空白や改行のみは連続送信しやすく、意図的に行われサーバの負荷になる可能性があるため。
- チャットの以前の内容を見れるように
## Additional info (optional)
- MkPaginationを変更したので、チャンネルなどの依存コンポーネントでバグが起こるかもしれません。
- チャンネルでは動作確認済みです。

## Checklist
- [ ] Read the [contribution guide](https://github.com/kokonect-link/cherrypick/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG_CHERRYPICK.md
- [ ] (If possible) Add tests
